### PR TITLE
Fix codefolding of cell magics

### DIFF
--- a/nbextensions/usability/codefolding/main.js
+++ b/nbextensions/usability/codefolding/main.js
@@ -110,9 +110,9 @@ define([
             var mode = cell.code_mirror.getOption('mode');
             /* use indent folding in Python */
             if (mode.name == 'ipython' ) {
-                cell.code_mirror.setOption('foldGutter',{rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.firstline, CodeMirror.fold.indent) });                        
+                cell.code_mirror.setOption('foldGutter',{rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.firstline, CodeMirror.fold.magic, CodeMirror.fold.indent) });                        
             } else {
-                cell.code_mirror.setOption('foldGutter',{rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.firstline, CodeMirror.fold.brace) });            
+                cell.code_mirror.setOption('foldGutter',{rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.firstline, CodeMirror.fold.magic, CodeMirror.fold.brace) });            
             }
             var gutters = cell.code_mirror.getOption('gutters');
                 var found = jQuery.inArray("CodeMirror-foldgutter", gutters);


### PR DESCRIPTION
Simple fix to re-enable codefolding for cell magics (cells starting with `%%`), see issue #613. This used to work, but somehow got messed up during reorganization. 